### PR TITLE
chore: Update Restaurant model query to search by city as well as name

### DIFF
--- a/back/common/models/Restaurant.js
+++ b/back/common/models/Restaurant.js
@@ -66,8 +66,14 @@ module.exports = {
     if (query) {
       return this.model.findAll({
         where: {
-          name: {
-            [Op.like]: `%${query.name}%`,
+          [Op.or]: {
+            name: {
+              [Op.like]: `%${query.name}%`,
+            },
+
+            city: {
+              [Op.like]: `%${query.name}%`,
+            },
           },
         },
       });


### PR DESCRIPTION
This commit modifies the Restaurant model query in the `findAll` method to search for restaurants based on both the name and the city. This allows users to search for restaurants using either the name or the city, providing more flexibility in the search functionality.